### PR TITLE
[Interactive] Introduce admin-endpoint for hqps engine

### DIFF
--- a/flex/ldbc-sf01-long-date/engine_config.yaml
+++ b/flex/ldbc-sf01-long-date/engine_config.yaml
@@ -8,8 +8,9 @@ log_level: INFO
 default_graph: ldbc
 compute_engine:
   type: hiactor
-  hosts:
+  workers:
     - localhost:10000
+  admin_endpoint: localhost:7777
   shard_num: 1
 compiler:
   planner:


### PR DESCRIPTION
Introduce new field: `admin_endpoint` for engine_config.
Rename `hosts` to `workers` for engine_config.