### PR TITLE
fix(interactive): Minor fix

### DIFF
--- a/flex/ldbc-sf01-long-date/audit_graph_schema.yaml
+++ b/flex/ldbc-sf01-long-date/audit_graph_schema.yaml
@@ -56,7 +56,7 @@ schema:
           property_name: birthday
           property_type:
             temporal:
-              date32:
+              timestamp:
         - property_id: 5
           property_name: creationDate
           property_type:


### PR DESCRIPTION
Currently `birthday` is stored as timestamp, not date.